### PR TITLE
Fix flickering sky if time is too high (Closes #200)

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaUpdateTimeTranslator.java
@@ -34,9 +34,9 @@ public class JavaUpdateTimeTranslator extends PacketTranslator<ServerUpdateTimeP
 
     @Override
     public void translate(ServerUpdateTimePacket packet, GeyserSession session) {
+        // https://minecraft.gamepedia.com/Day-night_cycle#24-hour_Minecraft_day
         SetTimePacket setTimePacket = new SetTimePacket();
-        setTimePacket.setTime((int) Math.abs(packet.getTime()));
-
+        setTimePacket.setTime((int) Math.abs(packet.getTime()) % 24000);
         session.getUpstream().sendPacket(setTimePacket);
     }
 }


### PR DESCRIPTION
This was caused because the max int size is 2,147,483,647, which is what Minecraft: Bedrock Edition uses in the time packet. In Minecraft: Java Edition, a long is used which has a max length of 9,223,372,036,854,775,807, thus causing the sky to bug out.

This commit uses the modulus operator with the max time value per-day of 24,000 to retrieve the remainder.